### PR TITLE
Add "ProtectWorksheet" Feature

### DIFF
--- a/FileFormat.Cells/Worksheet.cs
+++ b/FileFormat.Cells/Worksheet.cs
@@ -143,7 +143,7 @@ namespace FileFormat.Cells
             }
 
             // Save the worksheet data
-            worksheet.Save();
+            //worksheet.Save();
             
 
 
@@ -171,6 +171,39 @@ namespace FileFormat.Cells
             row.Append(cell);
             sheetData.sheetData.Append(row);
         }
+
+        public void ProtectSheet(string password, int sheetIndex)
+        {
+            SheetProtection sheetProtection = new SheetProtection()
+            {
+                Sheet = true,
+                Objects = true,
+                Scenarios = true,
+                Password = password,
+            };
+
+            var targetSheet = this.spreadsheetDocument.WorkbookPart.WorksheetParts.ElementAt(sheetIndex).Worksheet;
+
+            if (targetSheet.Elements<SheetProtection>().Any())
+            {
+                targetSheet.Elements<SheetProtection>().First().Remove();
+            }
+
+            targetSheet.InsertAt(sheetProtection, 0);
+        }
+
+        /// <summary>
+        /// Unprotects the worksheet.
+        /// </summary>
+        public void UnProtectSheet()
+        {
+            // Remove existing SheetProtection if exists
+            if (worksheet.Elements<SheetProtection>().Any())
+            {
+                worksheet.Elements<SheetProtection>().First().Remove();
+            }
+        }
+
 
         private static List<UInt32> AddStyle(ref Stylesheet stylesheet)
         {


### PR DESCRIPTION
This PR adds a new feature, "ProtectWorksheet," to the project. The aim of this feature is to enhance the security and integrity of worksheet data by allowing users to protect a worksheet with a password, thereby limiting unauthorized changes.

### Example Code

````
string filePath = "/Users/fahadadeelqazi/Downloads/test_fahad1.xlsx";
// for creating an empty Excel file
Workbook workbook = new Workbook();

Worksheet worksheet = new Worksheet(workbook);
worksheet.insertValue("A1", 1, "some data", 0);

worksheet.ProtectSheet("abc123456", 0);
worksheet.saveDataToSheet(0);
workbook.Save(filePath);`