### PR TITLE
Add FreezePane Functionality with Properties for Retrieving Freeze Settings

### DIFF
--- a/FileFormat.Cells_Tests/UnitTest1.cs
+++ b/FileFormat.Cells_Tests/UnitTest1.cs
@@ -1,5 +1,4 @@
-﻿
-using FileFormat.Cells;
+﻿using FileFormat.Cells;
 namespace FileFormat.Cells_Tests
 {
     [TestClass]
@@ -472,6 +471,56 @@ namespace FileFormat.Cells_Tests
             Assert.AreEqual(minValue, rule.MinValue);
             Assert.AreEqual(maxValue, rule.MaxValue);
         }
+
+        [TestMethod]
+        public void FreezePane_ShouldSetCorrectFreezePanesRow()
+        {
+            // Arrange
+            int expectedRows = 2;
+            int expectedColumns = 1;
+            using (Workbook wb = new Workbook(testFilePath))
+            {
+                Worksheet firstSheet = wb.Worksheets.First();
+
+                firstSheet.FreezePane(expectedRows, expectedColumns);
+
+                wb.Save();
+            }
+
+            using (Workbook wb = new Workbook(testFilePath))
+            {
+                Worksheet firstSheet = wb.Worksheets.First();
+
+                // Assert
+                Assert.AreEqual(expectedRows, firstSheet.FreezePanesRow, "FreezePanesColumn should match the columns frozen.");
+            }
+        }
+
+        [TestMethod]
+        public void FreezePane_ShouldSetCorrectFreezePanesColumn()
+        {
+            // Arrange
+            int expectedRows = 2;
+            int expectedColumns = 1;
+            using (Workbook wb = new Workbook(testFilePath))
+            {
+                Worksheet firstSheet = wb.Worksheets.First();
+
+                firstSheet.FreezePane(expectedRows, expectedColumns);
+
+                wb.Save();
+            }
+
+            using (Workbook wb = new Workbook(testFilePath))
+            {
+                Worksheet firstSheet = wb.Worksheets.First();
+
+                // Assert
+                Assert.AreEqual(expectedColumns, firstSheet.FreezePanesColumn, "FreezePanesColumn should match the columns frozen.");
+            }
+
+        }
+
 
         [TestMethod]
         public void CustomFormulaValidationRule_CreatesCorrectFormula()


### PR DESCRIPTION
# Add FreezePane Functionality with Properties for Retrieving Freeze Settings

This PR introduces a new `FreezePane` method in the `Worksheet` class, enabling specific rows and columns to be frozen. Key additions include:

- **Properties `FreezePanesRow` and `FreezePanesColumn`**: Allow retrieval of freeze settings for rows and columns.
- **Unit Tests**: Verifies that `FreezePanesRow` and `FreezePanesColumn` reflect the correct values after freezing.

These changes enhance the `Worksheet` API by providing easier access to pane freeze configurations, improving usability for developers working with worksheet layouts.